### PR TITLE
Add `--debug` option and `openephys` input

### DIFF
--- a/code/get_max_recording_duration_h.py
+++ b/code/get_max_recording_duration_h.py
@@ -1,0 +1,20 @@
+"""
+Print the maximum recording duration.
+"""
+from pathlib import Path
+import json
+import numpy as np
+
+
+results_folder = Path("../results")
+
+
+if __name__ == "__main__":
+    json_job_files = [p for p in results_folder.iterdir() if p.suffix == ".json" and "job" in p.name]
+    durations = []
+    for json_file in json_job_files:
+        with open(json_file, "r") as f:
+            job_dict = json.load(f)
+        durations.append(job_dict["duration"])
+    max_duration_h = int(np.round(np.max(durations)) / 3600)
+    print(max_duration_h)

--- a/code/get_max_recording_duration_min.py
+++ b/code/get_max_recording_duration_min.py
@@ -1,5 +1,5 @@
 """
-Print the maximum recording duration.
+Print the maximum recording duration in minutes.
 """
 from pathlib import Path
 import json
@@ -16,5 +16,7 @@ if __name__ == "__main__":
         with open(json_file, "r") as f:
             job_dict = json.load(f)
         durations.append(job_dict["duration"])
-    max_duration_h = int(np.round(np.max(durations)) / 3600)
-    print(max_duration_h)
+    max_duration_min = int(np.round(np.max(durations) / 60))
+    if max_duration_min < 1:
+        max_duration_min = 1
+    print(max_duration_min)

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -195,6 +195,12 @@ if __name__ == "__main__":
             if "acquisition" in electrical_series_path and "LFP" not in electrical_series_path:
                 stream_name = electrical_series_path.replace("/", "-")
                 recording = se.read_nwb_recording(nwb_file, electrical_series_path=electrical_series_path)
+                if recording.sampling_frequency < 10000:
+                    print(
+                        f"\t\t{electrical_series_path} is probably an LFP signal (sampling frequency: "
+                        f"{recording.sampling_frequency} Hz). Skipping"
+                    )
+                    continue
                 recording_name = f"block{block_index}_{stream_name}_recording"
                 recording_dict[(session_name, recording_name)] = {}
                 recording_dict[(session_name, recording_name)]["raw"] = recording

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -53,10 +53,6 @@ if __name__ == "__main__":
     print(f"\tINPUT: {INPUT}")
 
     print(f"Parsing {INPUT} input folder")
-
-    all_files = list(data_folder.iterdir())
-    print(f"Found {len(all_files)} files in the data folder:\n{all_files}")
-
     recording_dict = {}
     if INPUT == "aind":
         # find ecephys sessions to process
@@ -173,13 +169,11 @@ if __name__ == "__main__":
 
     elif INPUT == "nwb":
         # get blocks/experiments and streams info
-        nwb_files = [p for p in data_folder.glob("*.nwb*")]
-        print(nwb_files)
-        if len(all_files) == 1:
-            input_folder = all_files[0]
-            all_files_in_folder = list(input_folder.iterdir())
-            print(all_files_in_folder)
-        assert len(nwb_files) == 1, "Attach one NWB file at a time"
+        nwb_files = [p for p in data_folder.glob("*.nwb")]
+        if len(nwb_files) == 0:
+            raise ValueError("No NWB files found in the data folder")
+        elif len(nwb_files) > 1:
+            raise ValueError("Attach one NWB file at a time")
         nwb_file = nwb_files[0]
         session_name = nwb_file.name
 

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
 
     elif INPUT == "nwb":
         # get blocks/experiments and streams info
-        nwb_files = [p for p in data_folder.iterdir() if "nwb" in p.name]
+        nwb_files = [p for p in data_folder.glob("*.nwb*")]
         assert len(nwb_files) == 1, "Attach one NWB file at a time"
         nwb_file = nwb_files[0]
         session_name = nwb_file.name

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -330,6 +330,7 @@ if __name__ == "__main__":
                         recording_name=str(recording_name_group),
                         recording_dict=recording_group.to_dict(recursive=True, relative_to=data_folder),
                         skip_times=skip_times,
+                        duration=duration,
                         debug=DEBUG,
                     )
                     rec_str = f"\t{recording_name_group} - Duration: {duration} s - Num. channels: {recording_group.get_num_channels()}"
@@ -347,6 +348,7 @@ if __name__ == "__main__":
                     recording_name=str(recording_name_segment),
                     recording_dict=recording.to_dict(recursive=True, relative_to=data_folder),
                     skip_times=skip_times,
+                    duration=duration,
                     debug=DEBUG,
                 )
                 rec_str = f"\t{recording_name_segment} - Duration: {duration} s - Num. channels: {recording.get_num_channels()}"

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -169,7 +169,12 @@ if __name__ == "__main__":
 
     elif INPUT == "nwb":
         # get blocks/experiments and streams info
+        all_files = [p for p in data_folder.iterdir()]
+        all_all_files = [p for p in data_folder.glob()]
+        print(f"all_files: {all_files}")
+        print(f"all_all_files: {all_all_files}")
         nwb_files = [p for p in data_folder.glob("**/*.nwb")]
+        print(f"nwb_files: {nwb_files}")
         if len(nwb_files) == 0:
             raise ValueError("No NWB files found in the data folder")
         elif len(nwb_files) > 1:

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -53,6 +53,10 @@ if __name__ == "__main__":
     print(f"\tINPUT: {INPUT}")
 
     print(f"Parsing {INPUT} input folder")
+
+    all_files = list(data_folder.iterdir())
+    print(f"Found {len(all_files)} files in the data folder:\n{all_files}")
+
     recording_dict = {}
     if INPUT == "aind":
         # find ecephys sessions to process

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -170,7 +170,7 @@ if __name__ == "__main__":
     elif INPUT == "nwb":
         # get blocks/experiments and streams info
         all_files = [p for p in data_folder.iterdir()]
-        all_all_files = [p for p in data_folder.glob()]
+        all_all_files = [p for p in data_folder.glob("*")]
         print(f"all_files: {all_files}")
         print(f"all_all_files: {all_all_files}")
         nwb_files = [p for p in data_folder.glob("**/*.nwb")]

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -169,7 +169,7 @@ if __name__ == "__main__":
 
     elif INPUT == "nwb":
         # get blocks/experiments and streams info
-        nwb_files = [p for p in data_folder.glob("*.nwb")]
+        nwb_files = [p for p in data_folder.glob("**/*.nwb")]
         if len(nwb_files) == 0:
             raise ValueError("No NWB files found in the data folder")
         elif len(nwb_files) > 1:

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -169,11 +169,11 @@ if __name__ == "__main__":
 
     elif INPUT == "nwb":
         # get blocks/experiments and streams info
-        all_files = [p for p in data_folder.iterdir()]
-        all_all_files = [p for p in data_folder.glob("*")]
-        print(f"all_files: {all_files}")
-        print(f"all_all_files: {all_all_files}")
-        nwb_files = [p for p in data_folder.glob("**/*.nwb")]
+        all_input_folders = [p for p in data_folder.iterdir() if p.is_dir()]
+        if len(all_input_folders) == 1:
+            nwb_files = [p for p in all_input_folders[0].iterdir() if p.name.endswith(".nwb")]
+        else:
+            nwb_files = [p for p in data_folder.iterdir() if p.name.endswith(".nwb")]
         print(f"nwb_files: {nwb_files}")
         if len(nwb_files) == 0:
             raise ValueError("No NWB files found in the data folder")

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -192,11 +192,12 @@ if __name__ == "__main__":
         print(f"\tNum. Blocks {num_blocks} - Num. streams: {len(electrical_series_paths)}")
         for electrical_series_path in electrical_series_paths:
             # only use paths in acquisition
-            if "acquisition" in electrical_series_path:
+            if "acquisition" in electrical_series_path and "LFP" not in electrical_series_path:
                 stream_name = electrical_series_path.replace("/", "-")
                 recording = se.read_nwb_recording(nwb_file, electrical_series_path=electrical_series_path)
                 recording_name = f"block{block_index}_{stream_name}_recording"
-                recording_dict[(session_name, recording_name)] = recording
+                recording_dict[(session_name, recording_name)] = {}
+                recording_dict[(session_name, recording_name)]["raw"] = recording
 
     # populate job dict list
     job_dict_list = []

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -174,6 +174,11 @@ if __name__ == "__main__":
     elif INPUT == "nwb":
         # get blocks/experiments and streams info
         nwb_files = [p for p in data_folder.glob("*.nwb*")]
+        print(nwb_files)
+        if len(all_files) == 1:
+            input_folder = all_files[0]
+            all_files_in_folder = list(input_folder.iterdir())
+            print(all_files_in_folder)
         assert len(nwb_files) == 1, "Attach one NWB file at a time"
         nwb_file = nwb_files[0]
         session_name = nwb_file.name

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -238,7 +238,7 @@ if __name__ == "__main__":
         if len(nwb_files) == 0:
             raise ValueError("No NWB files found in the data folder")
         elif len(nwb_files) > 1:
-            raise ValueError("Attach one NWB file at a time")
+            raise ValueError("Multiple NWB files found in the data folder. Please only add one at a time")
         nwb_file = nwb_files[0]
         session_name = nwb_file.name
 
@@ -252,7 +252,7 @@ if __name__ == "__main__":
         print(f"\tNum. Blocks {num_blocks} - Num. streams: {len(electrical_series_paths)}")
         for electrical_series_path in electrical_series_paths:
             # only use paths in acquisition
-            if "acquisition" in electrical_series_path and "LFP" not in electrical_series_path:
+            if "acquisition" in electrical_series_path:
                 stream_name = electrical_series_path.replace("/", "-")
                 recording = se.read_nwb_recording(nwb_file, electrical_series_path=electrical_series_path)
                 if recording.sampling_frequency < 10000:


### PR DESCRIPTION
This PR moves the `--debug` and `--debug-duration` option to the job dispatch step (previously in the preprocessing) and adds a `debug` field to the `job_*.json`

This is convenient because several downstream processes might make use of such information.

In addition, this PR adds support for the `openephys` binary format is added.