### PR TITLE
Relax timestamps check before ignoring timestamps

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -6,7 +6,6 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 # GENERAL IMPORTS
 import argparse
 import numpy as np
-import warnings
 from pathlib import Path
 import json
 


### PR DESCRIPTION
This PR relaxes the criteria to ignore timestamps, in order to allow small timestamps glitches.

In particular, timestamps are ignored if:
-  there are more than 10 timestamps drops (negative diff)
OR
- if negative drops are detected, any timestamp diff is greater than 1 ms

@jsiegle let me know what you think